### PR TITLE
Enable Boost atomic for libfork

### DIFF
--- a/build_and_bench_all.py
+++ b/build_and_bench_all.py
@@ -10,7 +10,7 @@ import yaml
 import sys
 
 runtimes = {
-    "cpp": ["TooManyCooks", "libfork", "concurrencpp"]
+    "cpp": ["libfork", "TooManyCooks", "concurrencpp"]
 }
 
 runtime_links = {

--- a/cpp/libfork/CMakeLists.txt
+++ b/cpp/libfork/CMakeLists.txt
@@ -15,18 +15,30 @@ add_definitions(
     "-DLF_USE_HWLOC"
 )
 
+
+
 include(../1CMake/CPM.cmake)
+
+# Boost (atomic) really helps speed up libforks lock free datastructures due to bad Clang codegen.
+CPMAddPackage(
+  NAME Boost
+  VERSION 1.84.0
+  URL https://github.com/boostorg/boost/releases/download/boost-1.84.0/boost-1.84.0.tar.xz
+  URL_HASH SHA256=2e64e5d79a738d0fa6fb546c6e5c2bd28f88d268a2a080546f74e5ff98f29d0e
+  OPTIONS "BOOST_ENABLE_CMAKE ON" "BOOST_INCLUDE_LIBRARIES atomic"
+)
+
+# Becuase boost is not installed libfork would error if it tried to export the target.
+set(CMAKE_SKIP_INSTALL_RULES On)
 
 # My fork only fixes finding dependencies on my machine - no code changes to libfork.
 # If you want, you can use the original libfork:
 # https://github.com/ConorWilliams/libfork.git@v3.7.2
 CPMAddPackage(
     NAME libfork
-    GIT_REPOSITORY https://github.com/tzcnt/libfork.git
-    GIT_TAG 60ff97f80448e9d621c52d153028e9578eef5a23
-    DOWNLOAD_ONLY)
-include_directories(
-    ${libfork_SOURCE_DIR}/include
+    GIT_REPOSITORY https://github.com/conorwilliams/libfork.git
+    GIT_TAG v3.7.2
+    DOWNLOAD_ONLY
 )
 
 # Since each new coroutine requires an allocation,
@@ -57,8 +69,9 @@ else()
     endif()
 endif()
 
-link_libraries(${MALLOC_LIB} libfork::libfork hwloc)
 
 add_executable(fib fib.cpp)
+target_link_libraries(fib ${MALLOC_LIB} libfork::libfork)
 
 add_executable(skynet skynet.cpp)
+target_link_libraries(skynet ${MALLOC_LIB} libfork::libfork)


### PR DESCRIPTION
Nice work on TMC @tzcnt, I wanted to reproduce your benchmarks, before making any changes I measured:

| Runtime | [libfork](https://github.com/ConorWilliams/libfork) | [TooManyCooks](https://github.com/tzcnt/TooManyCooks) | [concurrencpp](https://github.com/David-Haim/concurrencpp) |
| --- | --- | --- | --- |
| Mean Ratio to Best<br>(lower is better) | 1.00x | 1.23x | 101.92x |
| fib(35) | 40951 us | 56524 us | 5106416 us |
| fib(40) | 375238 us | 466106 us | 54286115 us |
| skynet (first run) | 4548 us | 5739 us | 197476 us |
| skynet (last run) | 2054 us | 2120 us | 194946 us |


This PR adds Boost via CPM.cmake which libfork uses to further optimize some atomic operations. With this change I measure:

| Runtime | [libfork](https://github.com/ConorWilliams/libfork) | [TooManyCooks](https://github.com/tzcnt/TooManyCooks) | [concurrencpp](https://github.com/David-Haim/concurrencpp) |
| --- | --- | --- | --- |
| Mean Ratio to Best<br>(lower is better) | 1.00x | 2.13x | 141.36x |
| fib(35) | 27196 us | 61907 us | 4979572 us |
| fib(40) | 237295 us | 522692 us | 45134632 us |
| skynet (first run) | 2966 us | 6296 us | 182739 us |
| skynet (last run) | 1442 us | 2771 us | 188189 us |

After that I tried increasing the iteration count to 5 because I thought it may just me measuring start-up costs:

| Runtime | [libfork](https://github.com/ConorWilliams/libfork) | [TooManyCooks](https://github.com/tzcnt/TooManyCooks) | [concurrencpp](https://github.com/David-Haim/concurrencpp) |
| --- | --- | --- | --- |
| Mean Ratio to Best<br>(lower is better) | 1.00x | 1.93x | 173.87x |
| fib(35) | 114506 us | 248406 us | 24453129 us |
| fib(40) | 1153398 us | 2405182 us | 264214943 us |
| skynet (first run) | 10900 us | 18439 us | 920160 us |
| skynet (last run) | 5878 us | 10389 us | 990099 us |

Then excluding concurrencppas because it was taking too long I tried 100 iterations:

| Runtime | [libfork](https://github.com/ConorWilliams/libfork) | [TooManyCooks](https://github.com/tzcnt/TooManyCooks) |
| --- | --- | --- |
| Mean Ratio to Best<br>(lower is better) | 1.00x | 2.02x |
| fib(35) | 2030602 us | 4143195 us |
| fib(40) | 20100414 us | 44703982 us |
| skynet (first run) | 109094 us | 209574 us |
| skynet (last run) | 105766 us | 199429 us |

Now I think the variation observed in the last three runs is just due to lack of averaging/standard error. 

Any ideas why I could be observing such different results from you? 

I compiled the benchmarks with clang version 18.0.0 (git@github.com:llvm/llvm-project.git 8a9bbac6629686bd1107cc0742b343a67d37a3c9) and ran with 32 threads on this:

```
Architecture:                    x86_64
CPU op-mode(s):                  32-bit, 64-bit
Byte Order:                      Little Endian
Address sizes:                   46 bits physical, 57 bits virtual
CPU(s):                          64
On-line CPU(s) list:             0-63
Thread(s) per core:              2
Core(s) per socket:              16
Socket(s):                       2
NUMA node(s):                    2
Vendor ID:                       GenuineIntel
CPU family:                      6
Model:                           106
Model name:                      Intel(R) Xeon(R) Silver 4314 CPU @ 2.40GHz
Stepping:                        6
CPU MHz:                         2900.002
BogoMIPS:                        4800.00
Virtualisation:                  VT-x
L1d cache:                       1.5 MiB
L1i cache:                       1 MiB
L2 cache:                        40 MiB
L3 cache:                        48 MiB
NUMA node0 CPU(s):               0,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50,52,54,56,58,60,62
NUMA node1 CPU(s):               1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63
Vulnerability Itlb multihit:     Not affected
Vulnerability L1tf:              Not affected
Vulnerability Mds:               Not affected
Vulnerability Meltdown:          Not affected
Vulnerability Mmio stale data:   Mitigation; Clear CPU buffers; SMT vulnerable
Vulnerability Retbleed:          Not affected
Vulnerability Spec store bypass: Mitigation; Speculative Store Bypass disabled via prctl and seccomp
Vulnerability Spectre v1:        Mitigation; usercopy/swapgs barriers and __user pointer sanitization
Vulnerability Spectre v2:        Mitigation; Enhanced IBRS, IBPB conditional, RSB filling, PBRSB-eIBRS SW sequence
Vulnerability Srbds:             Not affected
Vulnerability Tsx async abort:   Not affected
Flags:                           fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe sys
                                 call nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni p
                                 clmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc
                                 _deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb cat_l3 invpcid_single ssbd mba ibrs ibp
                                 b stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid cqm
                                  rdt_a avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb intel_pt avx512cd sha_ni avx512bw avx512vl xsaveopt xsav
                                 ec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local wbnoinvd dtherm ida arat pln pts avx512vbmi umip pku os
                                 pke avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg tme avx512_vpopcntdq rdpid md_clear pconfig flush_l1d arch_
                                 capabilities
```  