### PR TITLE
Track peak memory usage

### DIFF
--- a/cpp/2common/memusage.hpp
+++ b/cpp/2common/memusage.hpp
@@ -1,0 +1,32 @@
+#pragma once
+#ifdef _WIN32
+#include <psapi.h>
+#include <windows.h>
+#else
+#include <sys/resource.h>
+#include <sys/param.h>
+#endif
+
+/**
+ * Returns peak memory usage in KiB
+ */
+static inline long peak_memory_usage() {
+#if defined(_WIN32)
+  PROCESS_MEMORY_COUNTERS pmc;
+  if (GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc))) {
+    return pmc.PeakWorkingSetSize / 1024;
+  }
+#else // Linux/BSD
+  rusage usage{};
+  if (getrusage(RUSAGE_SELF, &usage) == 0) {
+    // BSD based systems return maxrss in bytes,
+    // on Linux it is in kilobytes
+#if defined(BSD) || defined(__FreeBSD__) || defined(__APPLE__)
+    return usage.ru_maxrss / 1024;
+#else
+    return usage.ru_maxrss;
+#endif
+  }
+#endif
+  return -1;
+}

--- a/cpp/2common/memusage.hpp
+++ b/cpp/2common/memusage.hpp
@@ -1,7 +1,8 @@
 #pragma once
 #ifdef _WIN32
-#include <psapi.h>
+#define NOMINMAX
 #include <windows.h>
+#include <psapi.h>
 #else
 #include <sys/resource.h>
 #include <sys/param.h>

--- a/cpp/HPX/fib.cpp
+++ b/cpp/HPX/fib.cpp
@@ -26,6 +26,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include "memusage.hpp"
 #include <hpx/future.hpp>
 #include <hpx/init.hpp>
 
@@ -105,6 +106,7 @@ int hpx_main(hpx::program_options::variables_map&) {
   std::printf("runs:\n");
   std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
   std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 
   return hpx::local::finalize();
 }

--- a/cpp/HPX/matmul.cpp
+++ b/cpp/HPX/matmul.cpp
@@ -9,6 +9,7 @@
 
 #include "matmul.hpp"
 
+#include "memusage.hpp"
 #include <hpx/experimental/task_group.hpp>
 #include <hpx/future.hpp>
 #include <hpx/init.hpp>
@@ -94,6 +95,7 @@ void run_one(int N) {
     std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime);
   std::printf("  - matrix_size: %d\n", N);
   std::printf("    duration: %zu us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }
 
 int hpx_main(hpx::program_options::variables_map&) {

--- a/cpp/HPX/nqueens.cpp
+++ b/cpp/HPX/nqueens.cpp
@@ -10,6 +10,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#include "memusage.hpp"
 #include "hpx/async_combinators/when_all.hpp"
 #include <hpx/config.hpp>
 #include <hpx/experimental/task_group.hpp>
@@ -152,6 +153,7 @@ int hpx_main(hpx::program_options::variables_map& vm) {
   std::printf("runs:\n");
   std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
   std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 
   return hpx::local::finalize();
 }

--- a/cpp/HPX/skynet.cpp
+++ b/cpp/HPX/skynet.cpp
@@ -28,6 +28,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include "memusage.hpp"
 #include "hpx/async_combinators/when_all.hpp"
 #include <hpx/experimental/task_group.hpp>
 #include <hpx/future.hpp>
@@ -154,6 +155,7 @@ template <size_t Depth = 6> void loop_skynet() {
     std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime);
   std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
   std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }
 
 int hpx_main(hpx::program_options::variables_map&) {

--- a/cpp/TooManyCooks/channel.cpp
+++ b/cpp/TooManyCooks/channel.cpp
@@ -27,6 +27,7 @@
 
 #define TMC_IMPL
 
+#include "memusage.hpp"
 #include "tmc/all_headers.hpp"
 #include "tmc/asio/ex_asio.hpp"
 
@@ -188,4 +189,5 @@ int main(int argc, char* argv[]) {
   std::printf("    elements: %zu\n", element_count);
   std::printf("    duration: %zu us\n", totalTimeUs);
   std::printf("    elements/sec: %zu\n", elementsPerSec);
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }

--- a/cpp/TooManyCooks/fib.cpp
+++ b/cpp/TooManyCooks/fib.cpp
@@ -28,6 +28,7 @@
 
 #define TMC_IMPL
 
+#include "memusage.hpp"
 #include "tmc/all_headers.hpp"
 
 #include <chrono>
@@ -92,6 +93,7 @@ int main(int argc, char* argv[]) {
     std::printf("runs:\n");
     std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
     std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+    std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
     co_return 0;
   }(n));
 }

--- a/cpp/TooManyCooks/io_socket_st.cpp
+++ b/cpp/TooManyCooks/io_socket_st.cpp
@@ -36,6 +36,7 @@
 
 #define TMC_IMPL
 
+#include "memusage.hpp"
 #include "tmc/asio/aw_asio.hpp"
 #include "tmc/asio/ex_asio.hpp"
 #include "tmc/fork_group.hpp"
@@ -230,4 +231,5 @@ int main(int argc, char* argv[]) {
   std::printf(
     "    requests/sec: %zu\n", REQUEST_COUNT * 1000000 / totalTimeUs.count()
   );
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }

--- a/cpp/TooManyCooks/matmul.cpp
+++ b/cpp/TooManyCooks/matmul.cpp
@@ -9,6 +9,7 @@
 
 #define TMC_IMPL
 
+#include "memusage.hpp"
 #include "matmul.hpp"
 #include "tmc/all_headers.hpp"
 
@@ -84,6 +85,7 @@ void run_one(int N) {
     std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime);
   std::printf("  - matrix_size: %d\n", N);
   std::printf("    duration: %zu us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }
 
 int main(int argc, char* argv[]) {

--- a/cpp/TooManyCooks/nqueens.cpp
+++ b/cpp/TooManyCooks/nqueens.cpp
@@ -12,6 +12,7 @@
 
 #define TMC_IMPL
 
+#include "memusage.hpp"
 #include "tmc/ex_cpu.hpp"
 #include "tmc/spawn_many.hpp"
 #include "tmc/task.hpp"
@@ -107,6 +108,7 @@ int main(int argc, char* argv[]) {
     std::printf("runs:\n");
     std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
     std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+    std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
     co_return 0;
   }());
 }

--- a/cpp/TooManyCooks/skynet.cpp
+++ b/cpp/TooManyCooks/skynet.cpp
@@ -30,6 +30,7 @@
 
 #define TMC_IMPL
 
+#include "memusage.hpp"
 #include "tmc/ex_cpu.hpp"
 #include "tmc/spawn_many.hpp"
 #include "tmc/task.hpp"
@@ -96,6 +97,7 @@ template <size_t Depth = 6> tmc::task<void> loop_skynet() {
     std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime);
   std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
   std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }
 
 int main(int argc, char* argv[]) {

--- a/cpp/cobalt/channel.cpp
+++ b/cpp/cobalt/channel.cpp
@@ -25,6 +25,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include "memusage.hpp"
 #include <boost/cobalt.hpp>
 
 #include <chrono>
@@ -163,5 +164,6 @@ cobalt::main co_main(int argc, char* argv[]) {
   std::printf("    elements: %zu\n", element_count);
   std::printf("    duration: %zu us\n", totalTimeUs);
   std::printf("    elements/sec: %zu\n", elementsPerSec);
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
   co_return 0;
 }

--- a/cpp/cobalt/io_socket_st.cpp
+++ b/cpp/cobalt/io_socket_st.cpp
@@ -38,6 +38,7 @@
 
 #define TMC_IMPL
 
+#include "memusage.hpp"
 #include <boost/cobalt.hpp>
 #include <boost/cobalt/main.hpp>
 #include <boost/cobalt/this_coro.hpp>
@@ -207,4 +208,5 @@ int main(int argc, char* argv[]) {
   std::printf(
     "    requests/sec: %zu\n", REQUEST_COUNT * 1000000 / totalTimeUs.count()
   );
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }

--- a/cpp/concurrencpp/fib.cpp
+++ b/cpp/concurrencpp/fib.cpp
@@ -19,6 +19,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
 // THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+#include "memusage.hpp"
 #include "concurrencpp/concurrencpp.h"
 #include <cinttypes>
 #include <concurrencpp/runtime/runtime.h>
@@ -73,5 +74,6 @@ int main(int argc, char* argv[]) {
   std::printf("runs:\n");
   std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
   std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
   return 0;
 }

--- a/cpp/concurrencpp/matmul.cpp
+++ b/cpp/concurrencpp/matmul.cpp
@@ -7,6 +7,7 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include "memusage.hpp"
 #include "matmul.hpp"
 #include "concurrencpp/concurrencpp.h"
 #include <concurrencpp/results/constants.h>
@@ -93,6 +94,7 @@ void run_one(std::shared_ptr<thread_pool_executor> executor, int N) {
     std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime);
   std::printf("  - matrix_size: %d\n", N);
   std::printf("    duration: %zu us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }
 
 int main(int argc, char* argv[]) {

--- a/cpp/concurrencpp/nqueens.cpp
+++ b/cpp/concurrencpp/nqueens.cpp
@@ -10,6 +10,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#include "memusage.hpp"
 #include "concurrencpp/concurrencpp.h"
 #include <concurrencpp/runtime/runtime.h>
 
@@ -118,5 +119,6 @@ int main(int argc, char* argv[]) {
   std::printf("runs:\n");
   std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
   std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
   return 0;
 }

--- a/cpp/concurrencpp/skynet.cpp
+++ b/cpp/concurrencpp/skynet.cpp
@@ -28,6 +28,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include "memusage.hpp"
 #include "concurrencpp/concurrencpp.h"
 #include <concurrencpp/runtime/runtime.h>
 
@@ -90,6 +91,7 @@ loop_skynet(executor_tag, std::shared_ptr<thread_pool_executor> executor) {
     std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime);
   std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
   std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }
 
 int main(int argc, char* argv[]) {

--- a/cpp/coros/fib.cpp
+++ b/cpp/coros/fib.cpp
@@ -26,6 +26,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include "memusage.hpp"
 #include "start_tasks.h"
 #include "thread_pool.h"
 #include "wait_tasks.h"
@@ -80,4 +81,5 @@ int main(int argc, char* argv[]) {
   std::printf("runs:\n");
   std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
   std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }

--- a/cpp/coros/matmul.cpp
+++ b/cpp/coros/matmul.cpp
@@ -7,6 +7,7 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include "memusage.hpp"
 #include "matmul.hpp"
 #include "start_tasks.h"
 #include "thread_pool.h"
@@ -93,6 +94,7 @@ void run_one(coros::ThreadPool& executor, int N) {
     std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime);
   std::printf("  - matrix_size: %d\n", N);
   std::printf("    duration: %zu us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }
 
 int main(int argc, char* argv[]) {

--- a/cpp/coros/nqueens.cpp
+++ b/cpp/coros/nqueens.cpp
@@ -10,6 +10,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#include "memusage.hpp"
 #include "start_tasks.h"
 #include "thread_pool.h"
 #include "wait_tasks.h"
@@ -102,4 +103,5 @@ int main(int argc, char* argv[]) {
   std::printf("runs:\n");
   std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
   std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }

--- a/cpp/coros/skynet.cpp
+++ b/cpp/coros/skynet.cpp
@@ -28,6 +28,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include "memusage.hpp"
 #include "start_tasks.h"
 #include "thread_pool.h"
 #include "wait_tasks.h"
@@ -110,6 +111,7 @@ template <size_t Depth = 6> coros::Task<void> loop_skynet() {
     std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime);
   std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
   std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }
 
 int main(int argc, char* argv[]) {

--- a/cpp/cppcoro/fib.cpp
+++ b/cpp/cppcoro/fib.cpp
@@ -26,6 +26,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include "memusage.hpp"
 #include <cppcoro/schedule_on.hpp>
 #include <cppcoro/shared_task.hpp>
 #include <cppcoro/static_thread_pool.hpp>
@@ -93,6 +94,7 @@ int main(int argc, char* argv[]) {
       std::printf("runs:\n");
       std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
       std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+      std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
       co_return 0;
     }(tp, n)
   );

--- a/cpp/cppcoro/io_socket_st.cpp
+++ b/cpp/cppcoro/io_socket_st.cpp
@@ -35,6 +35,7 @@
 #undef linux
 #endif
 
+#include "memusage.hpp"
 #include <cppcoro/io_service.hpp>
 #include <cppcoro/net/socket.hpp>
 #include <cppcoro/on_scope_exit.hpp>
@@ -220,4 +221,5 @@ int main(int argc, char* argv[]) {
   std::printf(
     "    requests/sec: %zu\n", REQUEST_COUNT * 1000000 / totalTimeUs.count()
   );
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }

--- a/cpp/cppcoro/matmul.cpp
+++ b/cpp/cppcoro/matmul.cpp
@@ -7,6 +7,7 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include "memusage.hpp"
 #include "matmul.hpp"
 #include <cppcoro/schedule_on.hpp>
 #include <cppcoro/shared_task.hpp>
@@ -92,6 +93,7 @@ void run_one(cppcoro::static_thread_pool& tp, int N) {
     std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime);
   std::printf("  - matrix_size: %d\n", N);
   std::printf("    duration: %zu us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }
 
 int main(int argc, char* argv[]) {

--- a/cpp/cppcoro/nqueens.cpp
+++ b/cpp/cppcoro/nqueens.cpp
@@ -10,6 +10,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#include "memusage.hpp"
 #include <cppcoro/schedule_on.hpp>
 #include <cppcoro/shared_task.hpp>
 #include <cppcoro/static_thread_pool.hpp>
@@ -113,6 +114,7 @@ int main(int argc, char* argv[]) {
       std::printf("runs:\n");
       std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
       std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+      std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
       co_return 0;
     }(tp)
   );

--- a/cpp/cppcoro/skynet.cpp
+++ b/cpp/cppcoro/skynet.cpp
@@ -28,6 +28,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include "memusage.hpp"
 #include <cppcoro/schedule_on.hpp>
 #include <cppcoro/shared_task.hpp>
 #include <cppcoro/static_thread_pool.hpp>
@@ -97,6 +98,7 @@ cppcoro::task<void> loop_skynet(cppcoro::static_thread_pool& tp) {
     std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime);
   std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
   std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }
 
 int main(int argc, char* argv[]) {

--- a/cpp/libcoro/channel.cpp
+++ b/cpp/libcoro/channel.cpp
@@ -25,6 +25,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include "memusage.hpp"
 #include "coro/coro.hpp" // IWYU pragma: keep
 
 #include <chrono>
@@ -180,6 +181,7 @@ int main(int argc, char* argv[]) {
       std::printf("    elements: %zu\n", element_count);
       std::printf("    duration: %zu us\n", totalTimeUs);
       std::printf("    elements/sec: %zu\n", elementsPerSec);
+      std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
       co_return 0;
     }(tp)
   );

--- a/cpp/libcoro/fib.cpp
+++ b/cpp/libcoro/fib.cpp
@@ -26,6 +26,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include "memusage.hpp"
 #include "coro/coro.hpp" // IWYU pragma: keep
 
 #include <chrono>
@@ -81,6 +82,7 @@ int main(int argc, char* argv[]) {
       std::printf("runs:\n");
       std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
       std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+      std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
       co_return 0;
     }(*tp, n)
   );

--- a/cpp/libcoro/io_socket_st.cpp
+++ b/cpp/libcoro/io_socket_st.cpp
@@ -30,6 +30,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include "memusage.hpp"
 #include "coro/coro.hpp" // IWYU pragma: keep
 
 #include <cstddef>
@@ -255,4 +256,5 @@ int main(int argc, char* argv[]) {
   std::printf(
     "    requests/sec: %zu\n", REQUEST_COUNT * 1000000 / totalTimeUs.count()
   );
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }

--- a/cpp/libcoro/matmul.cpp
+++ b/cpp/libcoro/matmul.cpp
@@ -7,6 +7,7 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include "memusage.hpp"
 #include "matmul.hpp"
 #include "coro/coro.hpp" // IWYU pragma: keep
 
@@ -85,6 +86,7 @@ void run_one(coro::thread_pool& tp, int N) {
     std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime);
   std::printf("  - matrix_size: %d\n", N);
   std::printf("    duration: %zu us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }
 
 int main(int argc, char* argv[]) {

--- a/cpp/libcoro/nqueens.cpp
+++ b/cpp/libcoro/nqueens.cpp
@@ -10,6 +10,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#include "memusage.hpp"
 #include "coro/coro.hpp" // IWYU pragma: keep
 
 #include <array>
@@ -105,6 +106,7 @@ int main(int argc, char* argv[]) {
     std::printf("runs:\n");
     std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
     std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+    std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
     co_return 0;
   }(*tp));
 }

--- a/cpp/libcoro/skynet.cpp
+++ b/cpp/libcoro/skynet.cpp
@@ -28,6 +28,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include "memusage.hpp"
 #include "coro/coro.hpp" // IWYU pragma: keep
 
 #include <chrono>
@@ -85,6 +86,7 @@ coro::task<void> loop_skynet(coro::thread_pool& tp) {
     std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime);
   std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
   std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }
 
 int main(int argc, char* argv[]) {

--- a/cpp/libfork/fib.cpp
+++ b/cpp/libfork/fib.cpp
@@ -13,6 +13,7 @@
 #include <cinttypes>
 #include <cstdio>
 #include <cstdlib>
+#include "memusage.hpp"
 #include <libfork.hpp>
 
 static size_t thread_count = std::thread::hardware_concurrency() / 2;
@@ -61,5 +62,6 @@ int main(int argc, char* argv[]) {
   std::printf("runs:\n");
   std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
   std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
   return 0;
 }

--- a/cpp/libfork/matmul.cpp
+++ b/cpp/libfork/matmul.cpp
@@ -8,6 +8,7 @@
 // file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include "matmul.hpp"
+#include "memusage.hpp"
 #include <libfork.hpp>
 
 #include <chrono>
@@ -92,6 +93,7 @@ void run_one(lf::lazy_pool& executor, int N) {
     std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime);
   std::printf("  - matrix_size: %d\n", N);
   std::printf("    duration: %zu us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }
 
 int main(int argc, char* argv[]) {

--- a/cpp/libfork/nqueens.cpp
+++ b/cpp/libfork/nqueens.cpp
@@ -14,6 +14,7 @@
 #include <cinttypes>
 #include <cstdio>
 #include <cstdlib>
+#include "memusage.hpp"
 #include <libfork.hpp>
 #include <ranges>
 
@@ -114,5 +115,6 @@ int main(int argc, char* argv[]) {
   std::printf("runs:\n");
   std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
   std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
   return 0;
 }

--- a/cpp/libfork/skynet.cpp
+++ b/cpp/libfork/skynet.cpp
@@ -28,6 +28,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include "memusage.hpp"
 #include <libfork.hpp>
 
 #include <chrono>
@@ -85,6 +86,7 @@ inline constexpr auto loop_skynet = [](auto loop_skynet) -> lf::task<void> {
     std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime);
   std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
   std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 };
 
 int main(int argc, char* argv[]) {

--- a/cpp/taskflow/fib.cpp
+++ b/cpp/taskflow/fib.cpp
@@ -4,6 +4,7 @@
 // https://github.com/taskflow/taskflow/blob/v3.9.0/examples/fibonacci.cpp
 // Original author: taskflow
 
+#include "memusage.hpp"
 #include <taskflow/taskflow.hpp>
 
 #include <chrono>
@@ -65,4 +66,5 @@ int main(int argc, char* argv[]) {
   std::printf("runs:\n");
   std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
   std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }

--- a/cpp/taskflow/matmul.cpp
+++ b/cpp/taskflow/matmul.cpp
@@ -7,6 +7,7 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include "memusage.hpp"
 #include "matmul.hpp"
 #include <taskflow/algorithm/for_each.hpp>
 #include <taskflow/taskflow.hpp>
@@ -98,6 +99,7 @@ void run_one(tf::Executor& executor, int N) {
     std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime);
   std::printf("  - matrix_size: %d\n", N);
   std::printf("    duration: %zu us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }
 
 int main(int argc, char* argv[]) {

--- a/cpp/taskflow/nqueens.cpp
+++ b/cpp/taskflow/nqueens.cpp
@@ -10,6 +10,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#include "memusage.hpp"
 #include <taskflow/taskflow.hpp>
 
 #include <array>
@@ -110,4 +111,5 @@ int main(int argc, char* argv[]) {
   std::printf("runs:\n");
   std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
   std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }

--- a/cpp/taskflow/skynet.cpp
+++ b/cpp/taskflow/skynet.cpp
@@ -28,6 +28,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include "memusage.hpp"
 #include <taskflow/taskflow.hpp>
 
 #include <chrono>
@@ -88,6 +89,7 @@ template <size_t Depth = 6> void loop_skynet(tf::Executor& executor) {
     std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime);
   std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
   std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }
 
 int main(int argc, char* argv[]) {

--- a/cpp/tbb/fib.cpp
+++ b/cpp/tbb/fib.cpp
@@ -26,6 +26,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include "memusage.hpp"
 #include <tbb/tbb.h>
 
 #include <chrono>
@@ -78,4 +79,5 @@ int main(int argc, char* argv[]) {
   std::printf("runs:\n");
   std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
   std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }

--- a/cpp/tbb/matmul.cpp
+++ b/cpp/tbb/matmul.cpp
@@ -7,6 +7,7 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include "memusage.hpp"
 #include "matmul.hpp"
 #include <tbb/tbb.h>
 
@@ -91,6 +92,7 @@ void run_one(tbb::task_arena& executor, int N) {
     std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime);
   std::printf("  - matrix_size: %d\n", N);
   std::printf("    duration: %zu us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }
 
 int main(int argc, char* argv[]) {

--- a/cpp/tbb/nqueens.cpp
+++ b/cpp/tbb/nqueens.cpp
@@ -10,6 +10,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#include "memusage.hpp"
 #include <tbb/tbb.h>
 
 #include <array>
@@ -107,4 +108,5 @@ int main(int argc, char* argv[]) {
   std::printf("runs:\n");
   std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
   std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }

--- a/cpp/tbb/skynet.cpp
+++ b/cpp/tbb/skynet.cpp
@@ -28,6 +28,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include "memusage.hpp"
 #include <tbb/tbb.h>
 
 #include <chrono>
@@ -82,6 +83,7 @@ template <size_t Depth = 6> void loop_skynet() {
     std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime);
   std::printf("  - iteration_count: %" PRIu64 "\n", iter_count);
   std::printf("    duration: %" PRIu64 " us\n", totalTimeUs.count());
+  std::printf("    max_rss: %ld KiB\n", peak_memory_usage());
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
From #10 

> While running benchmarks, I encountered an unexpected and massive spike in memory consumption. Some libraries hit nearly 28 GiB of RAM, bringing my system almost to death. Luckily, I managed to kill the process just in time.
> 
> I think memory usage tracking will be very useful.
> 
> Additionally, it would be helpful to add a warning in the README to alert users about potential high memory usage.

Roughly what the table will look like

| Runtime      | libfork  | TooManyCooks | TooManyCooks_st_asio | TooManyCooks_mt | libcoro  | libcoro_mt | cobalt_st_asio | cobalt  |
|--------------|----------|--------------|----------------------|-----------------|----------|------------|----------------|---------|
| skynet       | 15.97 MB | 15.97 MB     | N/A                  | N/A             | 20.62 GB | N/A        | N/A            | N/A     |
| nqueens      | 15.97 MB | 15.97 MB     | N/A                  | N/A             | 5.37 GB  | N/A        | N/A            | N/A     |
| fib(39)      | 15.97 MB | 15.97 MB     | N/A                  | N/A             | 17.02 GB | N/A        | N/A            | N/A     |
| matmul(2048) | 59.66 MB | 57.09 MB     | N/A                  | N/A             | 60.93 MB | N/A        | N/A            | N/A     |
| io_socket_st | N/A      | 15.97 MB     | N/A                  | N/A             | 15.97 MB | N/A        | N/A            | 16.1 MB |
| channel      | N/A      | N/A          | 28.76 MB             | 31.39 MB        | N/A      | 15.97 MB   | 15.54 MB       | N/A     |
